### PR TITLE
ureadahead: Add --use-existing-trace option

### DIFF
--- a/src/trace.h
+++ b/src/trace.h
@@ -38,6 +38,7 @@ int trace (int daemonise, int timeout,
            const char *pack_file,  /* May be null */
            const char *path_prefix_filter,  /* May be null */
            const PathPrefixOption *path_prefix,
+           int use_existing_trace,
            int force_ssd_mode);
 
 NIH_END_EXTERN

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -111,6 +111,14 @@ static char *pack_file = NULL;
 static char *path_prefix_filter = NULL;
 
 /**
+ * use_existing_trace:
+ *
+ * Set to TRUE if tracing events (tracing/events/fs/*) used to build the pack
+ * file are enabled and disabled outside of ureadahead.
+ */
+static int use_existing_trace = FALSE;
+
+/**
  * force_ssd_mode:
  *
  * Querying sysfs to detect whether disk is rotational does not work for virtual
@@ -219,6 +227,8 @@ static NihOption options[] = {
 	  NULL, "PREFIX_FILTER", &path_prefix_filter, dup_string_handler },
 	{ 0, "pack-file", N_("Path of the pack file to use"),
 	  NULL, "PACK_FILE", &pack_file, dup_string_handler },
+	{ 0, "use-existing-trace", N_("do not enable or disable tracing events"),
+	  NULL, NULL, &use_existing_trace, NULL },
 	{ 0, "force-ssd-mode", N_("force ssd setting in pack file during tracing"),
 	  NULL, NULL, &force_ssd_mode, NULL },
 
@@ -311,7 +321,8 @@ main (int   argc,
 
 	/* Trace to generate new pack files */
 	if (trace (daemonise, timeout, filename, pack_file,
-		   path_prefix_filter, &path_prefix, force_ssd_mode) < 0) {
+		   path_prefix_filter, &path_prefix, use_existing_trace,
+		   force_ssd_mode) < 0) {
 		NihError *err;
 
 		err = nih_error_get ();


### PR DESCRIPTION
Provide a flag for cases where tracing events used to build the pack file are enabled and disabled outside of ureadahead. One reason is certain SELinux policies does not allow write access to tracing/events/fs/* from non-privileged processes.

Adds command line option: --use-existing-trace (off by default).

There is no functional effect if option is not used.

Link to original ChromeOS patch (option previously named --no-debug-tracing): https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay/+/refs/heads/main/sys-apps/ureadahead/files/ureadahead-0.100.0-no-debug-tracing.patch

Signed-off-by: Alan Ding <alanding@google.com>