### PR TITLE
ureadahead: Change --use-existing-trace to --user-existing-trace-events

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -130,7 +130,7 @@ trace (int daemonise,
        const char *pack_file,
        const char *path_prefix_filter,
        const PathPrefixOption *path_prefix,
-       int use_existing_trace,
+       int use_existing_trace_events,
        int force_ssd_mode)
 {
 	int                 dfd;
@@ -154,9 +154,9 @@ trace (int daemonise,
 		if (errno != ENOENT)
 			nih_return_system_error (-1);
 
+		/* Mount debugfs (and implicitly tracefs) if not already mounted */
 		dfd = open (PATH_DEBUGFS "/tracing", O_NOFOLLOW | O_RDONLY | O_NOATIME);
 	}
-	/* Mount debugfs (and implicitly tracefs) if not already mounted */
 	if (dfd < 0) {
 		if (errno != ENOENT)
 			nih_return_system_error (-1);
@@ -196,7 +196,7 @@ trace (int daemonise,
 	if (!num_cpus)
 		num_cpus = 1;
 
-	if (! use_existing_trace) {
+	if (! use_existing_trace_events) {
 		/* Enable tracing of open() syscalls */
 		if (set_value (dfd, "events/fs/do_sys_open/enable",
 			       TRUE, &old_sys_open_enabled) < 0)
@@ -257,7 +257,7 @@ trace (int daemonise,
 	if (set_value (dfd, "tracing_on",
 		       old_tracing_enabled, NULL) < 0)
 		goto error;
-	if (! use_existing_trace) {
+	if (! use_existing_trace_events) {
 		if (old_uselib_enabled >= 0)
 			if (set_value (dfd, "events/fs/uselib/enable",
 				       old_uselib_enabled, NULL) < 0)

--- a/src/trace.h
+++ b/src/trace.h
@@ -38,7 +38,7 @@ int trace (int daemonise, int timeout,
            const char *pack_file,  /* May be null */
            const char *path_prefix_filter,  /* May be null */
            const PathPrefixOption *path_prefix,
-           int use_existing_trace,
+           int use_existing_trace_events,
            int force_ssd_mode);
 
 NIH_END_EXTERN

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -111,12 +111,14 @@ static char *pack_file = NULL;
 static char *path_prefix_filter = NULL;
 
 /**
- * use_existing_trace:
+ * use_existing_trace_events:
  *
- * Set to TRUE if tracing events (tracing/events/fs/*) used to build the pack
- * file are enabled and disabled outside of ureadahead.
+ * Set to TRUE if trace events (tracing/events/fs/) used to build the pack file
+ * are enabled and disabled outside of ureadahead. Needed if trace events access
+ * is never allowed (while setting buffer size and tracing on/off is allowed) by
+ * the OS's SELinux policy.
  */
-static int use_existing_trace = FALSE;
+static int use_existing_trace_events = FALSE;
 
 /**
  * force_ssd_mode:
@@ -227,8 +229,8 @@ static NihOption options[] = {
 	  NULL, "PREFIX_FILTER", &path_prefix_filter, dup_string_handler },
 	{ 0, "pack-file", N_("Path of the pack file to use"),
 	  NULL, "PACK_FILE", &pack_file, dup_string_handler },
-	{ 0, "use-existing-trace", N_("do not enable or disable tracing events"),
-	  NULL, NULL, &use_existing_trace, NULL },
+	{ 0, "use-existing-trace-events", N_("do not enable or disable trace events"),
+	  NULL, NULL, &use_existing_trace_events, NULL },
 	{ 0, "force-ssd-mode", N_("force ssd setting in pack file during tracing"),
 	  NULL, NULL, &force_ssd_mode, NULL },
 
@@ -321,7 +323,7 @@ main (int   argc,
 
 	/* Trace to generate new pack files */
 	if (trace (daemonise, timeout, filename, pack_file,
-		   path_prefix_filter, &path_prefix, use_existing_trace,
+		   path_prefix_filter, &path_prefix, use_existing_trace_events,
 		   force_ssd_mode) < 0) {
 		NihError *err;
 


### PR DESCRIPTION
This better reflects actual usage as ureadahead is still directly using trace files with debugfs_tracing security context (e.g. tracing_on and buffer_size_kb) under /tracing. But with the command line option, it is not directly accessing any files in /tracing/events/* that uses security context debugfs_tracing_debug due to SElinux policy restrictions in some Operating Systems such as Android [1].

[1] https://source.android.com/docs/core/architecture/kernel/using-debugfs-12