### PR TITLE
ureadahead: Fix build warnings

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -189,7 +189,7 @@ trace (int daemonise,
 					num_cpus++;
 			}
 			free(line);
-			nih_message("Counted %d CPUs\n",num_cpus);
+			nih_message("Counted %zu CPUs\n",num_cpus);
 		}
 		fclose(fp);
 	}

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -113,7 +113,7 @@ static char *path_prefix_filter = NULL;
 /**
  * use_existing_trace:
  *
- * Set to TRUE if tracing events (tracing/events/fs/*) used to build the pack
+ * Set to TRUE if tracing events (tracing/events/fs/) used to build the pack
  * file are enabled and disabled outside of ureadahead.
  */
 static int use_existing_trace = FALSE;


### PR DESCRIPTION
Fix build warnings with incorrectly print formatting size_t type with %d where it should be %zu, and printing /* in a block comment.