### PR TITLE
Update control file to work with Debian bookworm.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ureadahead (0.100.1-0.1) unstable; urgency=low
+
+  * Update dependencies to build on Debian 12 (bookworm). Requires libnih
+    which requires small modification to build.
+
+ -- Junichi Uekawa <dancer@debian.org>  Wed, 18 Oct 2023 22:10:52 +0900
+
 ureadahead (0.100.0-20) artful; urgency=medium
 
   * Do not install upstart system jobs.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: required
 Maintainer: Scott James Remnant <scott@ubuntu.com>
 Standards-Version: 3.9.1
-Build-Depends: debhelper (>= 7.3.15ubuntu3), dh-autoreconf, dh-systemd, autopoint, pkg-config (>= 0.22), libnih-dev (>= 1.0.0), libblkid-dev (>= 2.16), e2fslibs-dev (>= 1.41)
+Build-Depends: debhelper (>= 7.3.15ubuntu3), dh-autoreconf, autopoint, pkg-config (>= 0.22), libnih-dev (>= 1.0.0), libblkid-dev (>= 2.16), libext2fs-dev
 
 Package: ureadahead
 Architecture: any


### PR DESCRIPTION
dh-systemd is merged to debhelper itself.
e2fslibs-dev changed name to libext2fs-dev.

still requires libnih which doesn't quite build now. I have a building version at
https://salsa.debian.org/dancer/libnih

