### PR TITLE
ureadahead: Fix ioprio_set was not effective in threads

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -833,11 +833,6 @@ do_readahead_ssd (PackFile *file,
 		}
 	}
 
-	if (syscall (__NR_ioprio_set, IOPRIO_WHO_PROCESS, getpid (),
-		     IOPRIO_IDLE_LOWEST) < 0)
-		nih_warn ("%s: %s", _("Failed to set I/O priority"),
-			  strerror (errno));
-
 	clock_gettime (CLOCK_MONOTONIC, &start);
 
 	ctx.file = file;
@@ -859,6 +854,11 @@ static void *
 ra_thread (void *ptr)
 {
 	struct thread_ctx *ctx = ptr;
+
+	if (syscall (__NR_ioprio_set, IOPRIO_WHO_PROCESS, 0,
+		     IOPRIO_IDLE_LOWEST) < 0)
+		nih_warn ("%s: %s", _("Failed to set I/O priority"),
+			  strerror (errno));
 
 	for (;;) {
 		size_t i;


### PR DESCRIPTION
`do_readahead_ssd` calls the `ioprio_set` syscall incorrectly. Since `pthread_create` does not set the `CLONE_IO` flag, we should call `ioprio_set` in each thread, not in the main thread. According to `ioprio_set(2)`,

> However, by default, the distinct threads of a process will not share
> the  same  I/O context. (..snip..) call  ioprio_set()  on  each of the
> threads.

This commit fixes this bug.