### PR TITLE
remove NIH_BEGIN/END_EXTERN block from the headers

### DIFF
--- a/src/file.h
+++ b/src/file.h
@@ -21,13 +21,6 @@
 
 #include <stdio.h>
 
-#include <nih/macros.h>
-
-
-NIH_BEGIN_EXTERN
-
 char *fgets_alloc (const void *parent, FILE *stream);
-
-NIH_END_EXTERN
 
 #endif /* UREADAHEAD_FILE_H */

--- a/src/pack.h
+++ b/src/pack.h
@@ -22,8 +22,6 @@
 #include <sys/types.h>
 
 #include <limits.h>
-
-#include <nih/macros.h>
 #include <nih/list.h>
 
 
@@ -72,8 +70,6 @@ typedef enum sort_option {
 } SortOption;
 
 
-NIH_BEGIN_EXTERN
-
 char *    pack_file_name            (const void *parent, const char *arg);
 char *    pack_file_name_for_mount  (const void *parent, const char *mount);
 char *    pack_file_name_for_device (const void *parent, dev_t dev);
@@ -85,8 +81,6 @@ int       write_pack                (const char *filename, PackFile *file);
 void      pack_dump                 (PackFile *file, SortOption sort);
 
 int       do_readahead              (PackFile *file, int daemonise);
-
-NIH_END_EXTERN
 
 #endif /* UREADAHEAD_PACK_H */
 

--- a/src/trace.h
+++ b/src/trace.h
@@ -22,11 +22,9 @@
 #include <limits.h>
 #include <sys/types.h>
 
-#include <nih/macros.h>
 #include <nih/list.h>
 
 
-NIH_BEGIN_EXTERN
 
 typedef struct path_prefix_option {
         dev_t st_dev;
@@ -40,7 +38,5 @@ int trace (int daemonise, int timeout,
            const PathPrefixOption *path_prefix,
            int use_existing_trace_events,
            int force_ssd_mode);
-
-NIH_END_EXTERN
 
 #endif /* UREADAHEAD_TRACE_H */

--- a/src/values.h
+++ b/src/values.h
@@ -29,15 +29,9 @@
 
 #include <fcntl.h>
 
-#include <nih/macros.h>
-
-
-NIH_BEGIN_EXTERN
 
 int get_value (int dfd, const char *path, int *value);
 int set_value (int dfd, const char *path, int value, int *oldvalue);
-
-NIH_END_EXTERN
 
 #endif /* UREADAHEAD_VALUES_H */
 


### PR DESCRIPTION
This is part of ongoing effort to decouple libnih from the ureadahead.

NIH_BEGIN/END_EXTERN expands to 'extern "C"' macro if `__cplusplus` constant is defined.
This is only relevant if the ureadahead codebase involves the usage of C++.

For now, remove them instead of replacing them with the equivalent defined in the ureadahead codebase.