### PR TITLE
Replace nih_assert with assert

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -25,6 +25,7 @@
 
 
 #include <stdio.h>
+#include <assert.h>
 #include <string.h>
 
 #include <nih/macros.h>
@@ -53,7 +54,7 @@ fgets_alloc (const void *parent,
         size_t buf_sz = 0;
 	size_t buf_len = 0;
 
-	nih_assert (stream != NULL);
+	assert (stream != NULL);
 
 	for (;;) {
 		char *ret;

--- a/src/file.c
+++ b/src/file.c
@@ -62,7 +62,8 @@ fgets_alloc (const void *parent,
 
 		if (buf_sz <= (buf_len + 1)) {
 			buf_sz += 4096;
-			buf = NIH_MUST (nih_realloc (buf, parent, buf_sz));
+			buf = nih_realloc (buf, parent, buf_sz);
+			assert (buf != NULL);
 		}
 
 		ret = fgets (buf + buf_len, buf_sz - buf_len, stream);

--- a/src/pack.c
+++ b/src/pack.c
@@ -33,6 +33,7 @@
 #include <time.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <assert.h>
 #include <limits.h>
 #include <string.h>
 #include <unistd.h>
@@ -129,7 +130,7 @@ pack_file_name_for_mount (const void *parent,
 {
 	char *file;
 
-	nih_assert (mount != NULL);
+	assert (mount != NULL);
 
 	/* Strip the initial slash, if it's the root mountpoint, just return
 	 * the default pack filename.
@@ -264,7 +265,7 @@ read_pack (const void *parent,
 	time_t          created;
 	char            buf[80];
 
-	nih_assert (filename != NULL);
+	assert (filename != NULL);
 
 	clock_gettime (CLOCK_MONOTONIC, &start);
 
@@ -406,8 +407,8 @@ write_pack (const char *filename,
 	char   hdr[8];
 	time_t now;
 
-	nih_assert (filename != NULL);
-	nih_assert (file != NULL);
+	assert (filename != NULL);
+	assert (file != NULL);
 
 	/* Open the file, making sure we truncate it and give it a
 	 * sane mode
@@ -501,8 +502,8 @@ print_time (const char *     message,
  	struct timespec end;
  	struct timespec span;
 
-	nih_assert (message != NULL);
-	nih_assert (start != NULL);
+	assert (message != NULL);
+	assert (start != NULL);
 
 	clock_gettime (CLOCK_MONOTONIC, &end);
 
@@ -535,8 +536,8 @@ pack_sort_compar (const void *a,
 	const struct pack_sort *ps_a;
 	const struct pack_sort *ps_b;
 
-	nih_assert (a != NULL);
-	nih_assert (b != NULL);
+	assert (a != NULL);
+	assert (b != NULL);
 
 	ps_a = a;
 	ps_b = b;
@@ -557,7 +558,7 @@ pack_dump (PackFile * file,
 	nih_local struct pack_sort *pack = NULL;
 	int                         page_size;
 
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	page_size = sysconf (_SC_PAGESIZE);
 
@@ -594,7 +595,7 @@ pack_dump (PackFile * file,
 			}
 			break;
 		default:
-			nih_assert_not_reached ();
+			__builtin_unreachable ();
 		}
 	}
 
@@ -682,7 +683,7 @@ do_readahead (PackFile *file,
 	int             nr_open;
 	struct rlimit   nofile;
 
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	/* Increase our maximum file open count so that we can actually
 	 * open everything; if the file is larger than the kernel limit,
@@ -721,7 +722,7 @@ do_readahead_hdd (PackFile *file,
 	ext2_filsys     fs = NULL;
 	nih_local int * fds = NULL;
 
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	/* Adjust our CPU and I/O priority, we want to stay in the
 	 * foreground and hog all bandwidth to avoid jumping around the
@@ -745,7 +746,7 @@ do_readahead_hdd (PackFile *file,
 	devname = blkid_devno_to_devname (file->dev);
 	if (devname
 	    && (! ext2fs_open (devname, 0, 0, 0, unix_io_manager, &fs))) {
-		nih_assert (fs != NULL);
+		assert (fs != NULL);
 
 		for (size_t i = 0; i < file->num_groups; i++)
 			preload_inode_group (fs, file->groups[i]);
@@ -791,10 +792,10 @@ preload_inode_group (ext2_filsys fs,
 {
 	ext2_inode_scan scan = NULL;
 
-	nih_assert (fs != NULL);
+	assert (fs != NULL);
 
 	if (! ext2fs_open_inode_scan (fs, 0, &scan)) {
-		nih_assert (scan != NULL);
+		assert (scan != NULL);
 
 		if (! ext2fs_inode_scan_goto_blockgroup (scan, group)) {
 			struct ext2_inode inode;
@@ -824,7 +825,7 @@ do_readahead_ssd (PackFile *file,
 	pthread_t         thread[NUM_THREADS];
 	struct thread_ctx ctx;
 
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	/* Can only --daemon for SSD */
 	if (daemonise) {

--- a/src/trace.c
+++ b/src/trace.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <assert.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
@@ -468,11 +469,11 @@ init_filemap_tep (struct tep_handle *tep, const char *event_name,
 	if (! filemap->event)
 		return;
 	filemap->inode = tep_find_field (filemap->event, "i_ino");
-	nih_assert (filemap->inode != NULL);
+	assert (filemap->inode != NULL);
 	filemap->device = tep_find_field (filemap->event, "s_dev");
-	nih_assert (filemap->device != NULL);
+	assert (filemap->device != NULL);
 	filemap->index = tep_find_field (filemap->event, "index");
-	nih_assert (filemap->index != NULL);
+	assert (filemap->index != NULL);
 	filemap->last_index = tep_find_field (filemap->event, "last_index");
 	/* last_index can be NULL since fault does not have it */
 }
@@ -521,9 +522,9 @@ read_trace (const void *parent,
 	struct tep_handle *tep;
 	struct read_trace_context context;
 
-	nih_assert (path_prefix != NULL);
-	nih_assert (files != NULL);
-	nih_assert (num_files != NULL);
+	assert (path_prefix != NULL);
+	assert (files != NULL);
+	assert (num_files != NULL);
 
 	tep = tracefs_local_events_system (NULL, systems);
 	if (!tep)
@@ -582,10 +583,10 @@ static void push_dir(struct dir_stack **dirs, char *dir)
 	struct dir_stack *d;
 
 	d = malloc(sizeof(*d));
-	nih_assert (d != NULL);
+	assert (d != NULL);
 
 	d->dir = strdup(dir);
-	nih_assert (d->dir != NULL);
+	assert (d->dir != NULL);
 
 	d->next = *dirs;
 	*dirs = d;
@@ -684,7 +685,7 @@ static int map_inodes(struct device_data *dev, unsigned device, char *fs,
 						snprintf(filename, PATH_MAX,
 							 "%s/%s", dir, dent->d_name);
 						inode->name = strdup(filename);
-						nih_assert (inode->name != NULL);
+						assert (inode->name != NULL);
 						/* Need to sort the inodes by order */
 						inodes[inos++] = inode;
 						inode->dev_name = dev->name;
@@ -755,10 +756,10 @@ add_inodes (struct device_data **device_hash, PackFile **files, size_t *num_file
 		 * were found in the trace.
 		 */
 		inodes = calloc(dev->nr_inodes, sizeof(*inodes));
-		nih_assert (inodes != NULL);
+		assert (inodes != NULL);
 
 		dev->name = strdup(mapname);
-		nih_assert(dev->name);
+		assert(dev->name);
 
 		inos = map_inodes(dev, device, mapname, inodes);
 
@@ -961,7 +962,7 @@ fix_path (char *pathname)
 {
 	char *ptr;
 
-	nih_assert (pathname != NULL);
+	assert (pathname != NULL);
 
 	for (ptr = pathname; *ptr; ptr++) {
 		size_t len;
@@ -1053,9 +1054,9 @@ trace_add_path (const void *parent,
 	 */
 	static char resolved_pathname[PATH_MAX];
 
-	nih_assert (pathname != NULL);
-	nih_assert (files != NULL);
-	nih_assert (num_files != NULL);
+	assert (pathname != NULL);
+	assert (files != NULL);
+	assert (num_files != NULL);
 
 	/* We can't really deal with relative paths since we don't know
 	 * the working directory that they were opened from.
@@ -1220,7 +1221,7 @@ trace_add_path (const void *parent,
 static int
 ignore_path (const char *pathname)
 {
-	nih_assert (pathname != NULL);
+	assert (pathname != NULL);
 
 	if (! strncmp (pathname, "/proc/", 6))
 		return TRUE;
@@ -1254,8 +1255,8 @@ trace_file (const void *parent,
 	int             rotational;
 	PackFile *      file;
 
-	nih_assert (files != NULL);
-	nih_assert (num_files != NULL);
+	assert (files != NULL);
+	assert (num_files != NULL);
 
 	/* Return any existing file structure for this device */
 	for (size_t i = 0; i < *num_files; i++)
@@ -1324,10 +1325,10 @@ trace_add_chunks (const void *parent,
 	off_t                    num_pages;
 	nih_local unsigned char *vec = NULL;
 
-	nih_assert (file != NULL);
-	nih_assert (path != NULL);
-	nih_assert (fd >= 0);
-	nih_assert (size > 0);
+	assert (file != NULL);
+	assert (path != NULL);
+	assert (fd >= 0);
+	assert (size > 0);
 
 	if (page_size < 0)
 		page_size = sysconf (_SC_PAGESIZE);
@@ -1416,7 +1417,7 @@ get_fiemap (const void *parent,
 {
 	struct fiemap *fiemap;
 
-	nih_assert (fd >= 0);
+	assert (fd >= 0);
 
 	fiemap = NIH_MUST (nih_new (parent, struct fiemap));
 	memset (fiemap, 0, sizeof (struct fiemap));
@@ -1471,10 +1472,10 @@ trace_add_extents (const void *parent,
 {
 	nih_local struct fiemap *fiemap = NULL;
 
-	nih_assert (file != NULL);
-	nih_assert (path != NULL);
-	nih_assert (fd >= 0);
-	nih_assert (size > 0);
+	assert (file != NULL);
+	assert (path != NULL);
+	assert (fd >= 0);
+	assert (size > 0);
 
 	/* Get the extents map for this chunk, then iterate the extents
 	 * and put those in the pack instead of the chunks.
@@ -1532,18 +1533,18 @@ trace_add_groups (const void *parent,
 	const char *devname;
 	ext2_filsys fs = NULL;
 
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	devname = blkid_devno_to_devname (file->dev);
 	if (devname
 	    && (! ext2fs_open (devname, 0, 0, 0, unix_io_manager, &fs))) {
-		nih_assert (fs != NULL);
+		assert (fs != NULL);
 		size_t            num_groups = 0;
 		nih_local size_t *num_inodes = NULL;
 		size_t            mean = 0;
 		size_t            hits = 0;
 
-		nih_assert (fs != NULL);
+		assert (fs != NULL);
 
 		/* Calculate the number of inode groups on this filesystem */
 		num_groups = ((fs->super->s_blocks_count - 1)
@@ -1594,8 +1595,8 @@ block_compar (const void *a,
 	const PackBlock *block_a = a;
 	const PackBlock *block_b = b;
 
-	nih_assert (block_a != NULL);
-	nih_assert (block_b != NULL);
+	assert (block_a != NULL);
+	assert (block_b != NULL);
 
 	if (block_a->physical < block_b->physical) {
 		return -1;
@@ -1610,7 +1611,7 @@ static int
 trace_sort_blocks (const void *parent,
 		   PackFile *  file)
 {
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	/* Sort the blocks array by physical location, since these are
 	 * read in a separate pass to opening files, there's no reason
@@ -1630,8 +1631,8 @@ path_compar (const void *a,
 	const PackPath * const *path_a = a;
 	const PackPath * const *path_b = b;
 
-	nih_assert (path_a != NULL);
-	nih_assert (path_b != NULL);
+	assert (path_a != NULL);
+	assert (path_b != NULL);
 
 	if ((*path_a)->group < (*path_b)->group) {
 		return -1;
@@ -1654,7 +1655,7 @@ trace_sort_paths (const void *parent,
 	nih_local size_t *   new_idx = NULL;
 	PackPath *           new_paths;
 
-	nih_assert (file != NULL);
+	assert (file != NULL);
 
 	/* Sort the paths array by ext2fs inode group, ino_t then path.
 	 *
@@ -1852,7 +1853,7 @@ static void add_map (struct inode_data *inode, off_t index, off_t last_index)
 	case 0:
 		/* Allocate 2: 1 for this element an 1 for the FILEMAP_START_MARK */
 		map = calloc (sizeof(*inode->map), 2);
-		nih_assert (map != NULL);
+		assert (map != NULL);
 
 		/* Add a buffer element at the beginning for cmp_file_map_range() */
 		map->start = FILEMAP_START_MARK;
@@ -1865,7 +1866,7 @@ static void add_map (struct inode_data *inode, off_t index, off_t last_index)
 		map = inode->map - 1;
 		/* Allocate three. 2 for the elements and one for the FILEMAP_START_MARK */
 		map = realloc (map, sizeof(*inode->map) * 3);
-		nih_assert (map != NULL);
+		assert (map != NULL);
 
 		inode->map = map + 1;
 
@@ -1899,7 +1900,7 @@ static void add_map (struct inode_data *inode, off_t index, off_t last_index)
 		/* Set map to the start of the allocation */
 		map = inode->map - 1;
 		map = realloc (map, sizeof(*map) * (inode->nr_maps + 2));
-		nih_assert (map != NULL);
+		assert (map != NULL);
 		map++;
 		inode->map = map;
 
@@ -1959,7 +1960,7 @@ static struct inode_data *add_inode (struct device_data *dev, unsigned long ino)
 	case 0:
 		/* Add a marker to the beginning of the array for the range compare */
 		inode = calloc (sizeof(key), 2);
-		nih_assert (inode != NULL);
+		assert (inode != NULL);
 		inode->inode = FILEMAP_START_MARK;
 		inode++;
 		dev->inodes = inode;
@@ -1967,7 +1968,7 @@ static struct inode_data *add_inode (struct device_data *dev, unsigned long ino)
 	case 1:
 		inode = dev->inodes - 1;
 		inode = realloc (inode, sizeof(key) * 3);
-		nih_assert (inode != NULL);
+		assert (inode != NULL);
 		dev->inodes = inode + 1;
 
 		/* If the current element is greater than the new one, then move it */
@@ -1994,7 +1995,7 @@ static struct inode_data *add_inode (struct device_data *dev, unsigned long ino)
 		/* Set to the start of the allocated array */
 		inode = dev->inodes - 1;
 		inode = realloc (inode, sizeof(key) * (dev->nr_inodes + 2));
-		nih_assert (inode != NULL);
+		assert (inode != NULL);
 		inode++;
 		dev->inodes = inode;
 
@@ -2067,7 +2068,7 @@ static struct device_data *add_device (struct device_data **device_hash,
 	int key = id & HASH_MASK;
 
 	dev = calloc (1, sizeof(*dev));
-	nih_assert (dev != NULL);
+	assert (dev != NULL);
 
 	dev->id = id;
 	dev->next = device_hash[key];

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -172,7 +172,8 @@ dup_string_handler (NihOption   *option,
 	assert (arg != NULL);
 
 	char **value = (char **)option->value;
-	*value = NIH_MUST (nih_strdup (NULL, arg));
+	*value = nih_strdup (NULL, arg);
+	assert (*value != NULL);
 	return 0;
 }
 
@@ -269,8 +270,10 @@ main (int   argc,
 	 * (if any).
 	 */
 	filename = pack_file
-		? NIH_MUST (nih_strdup (NULL, pack_file))
+		? nih_strdup (NULL, pack_file)
 		: pack_file_name (NULL, args[0]);
+
+	assert (filename != NULL);
 
 	if (! force_trace) {
 		NihError *err;

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -33,6 +33,7 @@
 #include <sys/param.h>
 
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -136,9 +137,9 @@ path_prefix_option (NihOption  *option,
 	struct stat st;
 	dev_t st_dev;
 
-	nih_assert (option != NULL);
-	nih_assert (option->value != NULL);
-	nih_assert (arg != NULL);
+	assert (option != NULL);
+	assert (option->value != NULL);
+	assert (arg != NULL);
 
 	value = (PathPrefixOption *)option->value;
 
@@ -166,9 +167,9 @@ static int
 dup_string_handler (NihOption   *option,
 		    const char  *arg)
 {
-	nih_assert (option != NULL);
-	nih_assert (option->value != NULL);
-	nih_assert (arg != NULL);
+	assert (option != NULL);
+	assert (option->value != NULL);
+	assert (arg != NULL);
 
 	char **value = (char **)option->value;
 	*value = NIH_MUST (nih_strdup (NULL, arg));
@@ -181,9 +182,9 @@ sort_option (NihOption  *option,
 {
 	SortOption *value;
 
-	nih_assert (option != NULL);
-	nih_assert (option->value != NULL);
-	nih_assert (arg != NULL);
+	assert (option != NULL);
+	assert (option->value != NULL);
+	assert (arg != NULL);
 
 	value = (SortOption *)option->value;
 

--- a/src/values.c
+++ b/src/values.c
@@ -31,6 +31,7 @@
 
 #include <fcntl.h>
 #include <stdio.h>
+#include <assert.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -50,8 +51,8 @@ get_value (int         dfd,
 	char    buf[80];
 	ssize_t len;
 
-	nih_assert (path != NULL);
-	nih_assert (value != NULL);
+	assert (path != NULL);
+	assert (value != NULL);
 
 	fd = openat (dfd, path, O_RDONLY);
 	if (fd < 0)
@@ -83,7 +84,7 @@ set_value (int         dfd,
 	char    buf[80];
 	ssize_t len;
 
-	nih_assert (path != NULL);
+	assert (path != NULL);
 
 	fd = openat (dfd, path, O_RDWR);
 	if (fd < 0)
@@ -100,7 +101,7 @@ set_value (int         dfd,
 		buf[len] = '\0';
 		*oldvalue = atoi (buf);
 
-		nih_assert (lseek (fd, 0, SEEK_SET) == 0);
+		assert (lseek (fd, 0, SEEK_SET) == 0);
 	}
 
 	snprintf (buf, sizeof buf, "%d", value);
@@ -112,7 +113,7 @@ set_value (int         dfd,
 		return -1;
 	}
 
-	nih_assert (len > 0);
+	assert (len > 0);
 
 	if (close (fd) < 0)
 		nih_return_system_error (-1);


### PR DESCRIPTION
This is part of ongoing effort to decouple libnih from the ureadahead.

nih_assert performs condition check, print out the fatal log if it fails and then immediately calls abort().

This behavior is almost the same as assert defined by C standard, except the formatting of the message.  
this makes replacing all of them with normal assert a viable change.

nih_assert_not_reached is replaced with __builtin_unreachable.