### PR TITLE
Fix: path name resolved from symlink can exceed PACK_PATH_MAX

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -1107,6 +1107,14 @@ trace_add_path (const void *parent,
 
 		pathname = resolved_pathname;
 
+		/* Prevent resolved_path_name from going above
+		 * PACK_PATH_MAX.
+		 */
+		if (strlen (resolved_pathname) > PACK_PATH_MAX) {
+			nih_warn ("%s: %s", resolved_pathname, _("Ignored far too long path"));
+			return 0;
+		}
+
 		if (! maybe_insert_new_path (path_hash, resolved_pathname))
 			return 0;
 


### PR DESCRIPTION
Pull request #15 has a chance of storing invalid path name to a pack file, resulting in unnecessary excess data.

Pull request #15 did not properly check if the legnth of resolved path name exceeds the length of PACK_PATH_MAX. This path will be cut off into length of PACK_PATH_MAX when storing into a pack file, turning into an invalid path that ureadahead won't be able to open during replay phase.