### PR TITLE
Fix: assertion fails when logging empty string

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -50,13 +50,13 @@ void log_write (enum LogSeverity severity, const char *format, ...)
 		written = fprintf (stderr, "[%s] ureadahead: ", severity_str);
 		fp = stderr;
 
-		assert (written > 0);
+		assert (written >= 0);
 	}
 
 	va_start (va, format);
 	written = vfprintf (fp, format, va);
 	va_end (va);
-	assert (written > 0);
+	assert (written >= 0);
 
 	fputc ('\n', fp);
 }


### PR DESCRIPTION
Newly introduced logger had a slight typo that triggers unexpected assertion failure.

The logger unexpectedly enforces each log attempt to write at least one byte, by doing `assert(written > 0)`. This assertion will fail when ureadahead is running with `--dump` option, when it tries to write a zero length string with `log_messages("%s", "")`.

This change will fix this issue by checking for `written >= 0` case instead.

