### PR TITLE
Allow simultaneous recording and replaying

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -813,9 +813,14 @@ do_readahead_hdd (PackFile *file,
 				    file->blocks[i].length);
 	}
 
+	for (size_t i = 0; i < file->num_paths; i++) {
+		if (fds[i] < 0)
+			continue;
+		close(fds[i]);
+	}
+
 	free (fds);
 	print_time ("Readahead", &start);
-
 	return 0;
 }
 
@@ -932,6 +937,8 @@ ra_thread (void *ptr)
 					    ctx->file->blocks[i].length);
 		} while ((++i < ctx->file->num_blocks)
 			 && (ctx->file->blocks[i].pathidx == pathidx));
+
+		close(fd);
 	}
 
 	return NULL;

--- a/src/trace.c
+++ b/src/trace.c
@@ -292,6 +292,26 @@ trace_begin (struct trace_context *ctx,
 	return 0;
 }
 
+void
+trace_cancel (struct trace_context *ctx,
+	      int use_existing_trace_events)
+{
+	/* Force-stop and restore every configuration. */
+	if (ctx->old_tracing_enabled == 0)
+		tracefs_trace_off (NULL);
+
+	if (! use_existing_trace_events) {
+		for (int i = 0; i < NR_EVENTS; i++) {
+			if (ctx->old_events_enabled[i] > 0)
+				continue;
+			tracefs_event_disable (NULL,
+					       EVENTS[i][0], EVENTS[i][1]);
+		}
+	}
+
+	tracefs_instance_set_buffer_size (NULL, ctx->old_buffer_size_kb, -1);
+}
+
 int
 trace_process_events (struct trace_context *ctx,
 		      const char *filename_to_replace,

--- a/src/trace.c
+++ b/src/trace.c
@@ -90,41 +90,6 @@
  **/
 #define PAGE_SHIFT	12
 
-/**
- * FS_SYSTEM
- *
- * "fs" subsystem of the tracefs.
- **/
-#define FS_SYSTEM "fs"
-
-/**
- * FILEMAP_SYSTEM
- *
- * "filemap" subsystem of the tracefs.
- **/
-#define FILEMAP_SYSTEM	"filemap"
-
-/**
- * EVENTS:
- *
- * TraceFS events to enable.
- *
- **/
-static const char *EVENTS[][2] = {
-	/* required events for trace to work */
-	{FS_SYSTEM, "do_sys_open"},
-	{FS_SYSTEM, "open_exec"},
-	/* The below events can also work */
-	{FILEMAP_SYSTEM, "mm_filemap_fault"},
-	{FILEMAP_SYSTEM, "mm_filemap_get_pages"},
-	{FILEMAP_SYSTEM, "mm_filemap_map_pages"},
-	/* optional events follow */
-	{FS_SYSTEM, "uselib"}};
-
-#define NR_REQUIRED_EVENTS 2
-#define NR_ALTERNATE_REQUIRED_EVENTS (2 + 3)
-#define NR_EVENTS (sizeof (EVENTS) / sizeof (EVENTS[0]))
-
 #define _STRINGIFY(x) #x
 #define STRINGIFY(x) _STRINGIFY(x)
 

--- a/src/trace.c
+++ b/src/trace.c
@@ -235,25 +235,17 @@ sig_interrupt (int signum)
 {
 }
 
+static struct sigaction  old_sigterm;
+static struct sigaction  old_sigint;
+
 int
-trace (struct trace_context *ctx,
-       int daemonise,
-       int timeout,
-       const char *filename_to_replace,
-       const char *pack_file,
-       const char *path_prefix_filter,
-       const PathPrefixOption *path_prefix,
-       int use_existing_trace_events,
-       int force_ssd_mode)
+trace_begin (struct trace_context *ctx,
+	     int daemonise,
+	     int use_existing_trace_events,
+	     int timeout)
 {
 	struct sigaction  act;
-	struct sigaction  old_sigterm;
-	struct sigaction  old_sigint;
 	struct timeval    tv;
-	/* malloc'ed by read_trace, need free */
-	PackFile *        files = NULL;
-	size_t            num_files = 0;
-	int               err = 0;
 
 	if (! use_existing_trace_events) {
 		bool failed = false;
@@ -326,6 +318,22 @@ trace (struct trace_context *ctx,
 	} else {
 		pause ();
 	}
+
+	return 0;
+}
+
+int
+trace_process_events (struct trace_context *ctx,
+		      const char *filename_to_replace,
+		      const char *pack_file, /* Nullable */
+		      const char *path_prefix_filter, /* Nullable */
+		      const PathPrefixOption *path_prefix,
+		      int use_existing_trace_events,
+		      int force_ssd_mode)
+{
+	/* malloc'ed by read_trace, need free */
+	PackFile *files = NULL;
+	size_t    num_files = 0;
 
 	sigaction (SIGTERM, &old_sigterm, NULL);
 	sigaction (SIGINT, &old_sigint, NULL);

--- a/src/trace.h
+++ b/src/trace.h
@@ -88,13 +88,17 @@ struct trace_context {
 	int old_buffer_size_kb;
 };
 
-int trace (struct trace_context *ctx,
-           int daemonise, int timeout,
-           const char *filename_to_replace,
-           const char *pack_file,  /* May be null */
-           const char *path_prefix_filter,  /* May be null */
-           const PathPrefixOption *path_prefix,
-           int use_existing_trace_events,
-           int force_ssd_mode);
+int trace_begin (struct trace_context *ctx,
+		 int daemonise,
+		 int use_existing_trace_events,
+		 int timeout);
+
+int trace_process_events (struct trace_context *ctx,
+			  const char *filename_to_replace,
+			  const char *pack_file, /* Nullable */
+			  const char *path_prefix_filter, /* Nullable */
+			  const PathPrefixOption *path_prefix,
+			  int use_existing_trace_events,
+			  int force_ssd_mode);
 
 #endif /* UREADAHEAD_TRACE_H */

--- a/src/trace.h
+++ b/src/trace.h
@@ -23,6 +23,40 @@
 #include <sys/types.h>
 
 
+/**
+ * FS_SYSTEM
+ *
+ * "fs" subsystem of the tracefs.
+ **/
+#define FS_SYSTEM "fs"
+
+/**
+ * FILEMAP_SYSTEM
+ *
+ * "filemap" subsystem of the tracefs.
+ **/
+#define FILEMAP_SYSTEM	"filemap"
+
+/**
+ * EVENTS:
+ *
+ * TraceFS events to enable.
+ *
+ **/
+static const char *EVENTS[][2] = {
+	/* required events for trace to work */
+	{FS_SYSTEM, "do_sys_open"},
+	{FS_SYSTEM, "open_exec"},
+	/* The below events can also work */
+	{FILEMAP_SYSTEM, "mm_filemap_fault"},
+	{FILEMAP_SYSTEM, "mm_filemap_get_pages"},
+	{FILEMAP_SYSTEM, "mm_filemap_map_pages"},
+	/* optional events follow */
+	{FS_SYSTEM, "uselib"}};
+
+#define NR_REQUIRED_EVENTS 2
+#define NR_ALTERNATE_REQUIRED_EVENTS (2 + 3)
+#define NR_EVENTS (sizeof (EVENTS) / sizeof (EVENTS[0]))
 
 typedef struct path_prefix_option {
         dev_t st_dev;

--- a/src/trace.h
+++ b/src/trace.h
@@ -92,6 +92,9 @@ int trace_begin (struct trace_context *ctx,
 		 int daemonise,
 		 int use_existing_trace_events);
 
+void trace_cancel (struct trace_context *ctx,
+		   int use_existing_trace_events);
+
 int trace_process_events (struct trace_context *ctx,
 			  const char *filename_to_replace,
 			  const char *pack_file, /* Nullable */

--- a/src/trace.h
+++ b/src/trace.h
@@ -54,8 +54,27 @@ static const char *EVENTS[][2] = {
 	/* optional events follow */
 	{FS_SYSTEM, "uselib"}};
 
+/**
+ * NR_REQUIRED_EVENTS:
+ *
+ * Number of required events for ureadahead to function.
+ * NOTE: make sure to match the number with the content of EVENTS above.
+ **/
 #define NR_REQUIRED_EVENTS 2
+
+/**
+ * NR_ALTERNATE_REQUIRED_EVENTS:
+ *
+ * Number of required events for ureadahead to achieve full potential.
+ * NOTE: make sure to match the number with the content of EVENTS above.
+ **/
 #define NR_ALTERNATE_REQUIRED_EVENTS (2 + 3)
+
+/**
+ * NR_EVENTS:
+ *
+ * Number of total events.
+ **/
 #define NR_EVENTS (sizeof (EVENTS) / sizeof (EVENTS[0]))
 
 typedef struct path_prefix_option {

--- a/src/trace.h
+++ b/src/trace.h
@@ -82,7 +82,14 @@ typedef struct path_prefix_option {
         char prefix[PATH_MAX];
 } PathPrefixOption;
 
-int trace (int daemonise, int timeout,
+struct trace_context {
+	int old_events_enabled[NR_EVENTS];
+	int old_tracing_enabled;
+	int old_buffer_size_kb;
+};
+
+int trace (struct trace_context *ctx,
+           int daemonise, int timeout,
            const char *filename_to_replace,
            const char *pack_file,  /* May be null */
            const char *path_prefix_filter,  /* May be null */

--- a/src/trace.h
+++ b/src/trace.h
@@ -90,8 +90,7 @@ struct trace_context {
 
 int trace_begin (struct trace_context *ctx,
 		 int daemonise,
-		 int use_existing_trace_events,
-		 int timeout);
+		 int use_existing_trace_events);
 
 int trace_process_events (struct trace_context *ctx,
 			  const char *filename_to_replace,

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -366,6 +366,8 @@ main (int   argc,
 
 	assert (filename != NULL);
 
+	struct trace_context trace_ctx;
+
 	if (! force_trace) {
 		/* Read the current pack file */
 		file = read_pack (filename, dump_pack);
@@ -396,7 +398,7 @@ main (int   argc,
 	}
 
 	/* Trace to generate new pack files */
-	if (trace (daemonise, timeout, filename, pack_file,
+	if (trace (&trace_ctx, daemonise, timeout, filename, pack_file,
 		   path_prefix_filter, &path_prefix, use_existing_trace_events,
 		   force_ssd_mode) < 0) {
 		log_error ("Error while tracing. aborting");

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -398,11 +398,18 @@ main (int   argc,
 	}
 
 	/* Trace to generate new pack files */
-	if (trace (&trace_ctx, daemonise, timeout, filename, pack_file,
-		   path_prefix_filter, &path_prefix, use_existing_trace_events,
-		   force_ssd_mode) < 0) {
-		log_error ("Error while tracing. aborting");
-		exit (5);
+	if (trace_begin (&trace_ctx, daemonise, use_existing_trace_events,
+			 timeout) < 0) {
+		log_fatal ("Failed to enable tracepoints for recording. exiting");
+		exit (6);
+	}
+
+	if (trace_process_events (&trace_ctx, filename, pack_file,
+				  path_prefix_filter,  &path_prefix,
+				  use_existing_trace_events,
+				  force_ssd_mode) < 0) {
+		log_error ("Failed to process trace events, exiting.");
+		exit (7);
 	}
 
 	if (file)

--- a/src/ureadahead.c
+++ b/src/ureadahead.c
@@ -442,6 +442,7 @@ main (int   argc,
 		if (file) {
 			if (do_readahead (file, daemonise) < 0) {
 				log_fatal ("Failed to perform readahead. exiting");
+				trace_cancel (&trace_ctx, use_existing_trace_events);
 				exit (3);
 			}
 		}


### PR DESCRIPTION
This change depends on #23.

This change adds a new feature to ureadahead, that allows performing recording and replaying simultaneously.

Currently, the ureadahead only performs one of the two steps depending on the existence of the pack file: if it exists, perform playback using the pack file. if it does not exist, record the trace events and create one from the recorded events. 

Because pack file persists after initially created, any change to file access pattern could invalidate some entry in the pack file without ureadahead even knowing. This leads to effectiveness of ureadahead slowly diminishing over time, unless you explicitly renew the pack file by deleting it.

Instead of only performing only one step out of two based on the existence of pack file, this change will perform both steps at the same time, and regenerate a pack file each time it executes. thanks to three new kernel points introduced in #8, This change will refine the pack file each time ureadahead executes, allowing pack file to be kept up-to-date without manual removal nor expiration.