### PR TITLE
configure: Add touch to files to prevent rebuilding

### DIFF
--- a/configure
+++ b/configure
@@ -17,6 +17,10 @@
 ## M4sh Initialization. ##
 ## -------------------- ##
 
+# Added to fix time stamps
+
+touch Makefile.am Makefile.in aclocal.m4 configure config.h.in
+
 # Be more Bourne compatible
 DUALCASE=1; export DUALCASE # for MKS sh
 as_nop=:


### PR DESCRIPTION
Because git does not keep timestamps of files, running ./configure from a git checkout can cause files that are already made to be remade and that can make it fill he build because it may cause files to be built with different versions of autoconf.

Add a touch command to update the timestamps of the files:

 Makefile.am Makefile.in aclocal.m4 configure config.h.in

This will prevent the ./configure from messing with the tree. It will even not modify current files where git will show files were changed.