### PR TITLE
Fix: missing `close(fd)` in trace code can leak open fd

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -1139,8 +1139,10 @@ trace_add_path (const char *pathname,
 		assert (inode_hash != NULL);
 	}
 
-	if (! maybe_insert_dev_inode_pair (inode_hash, statbuf.st_dev, statbuf.st_ino))
+	if (! maybe_insert_dev_inode_pair (inode_hash, statbuf.st_dev, statbuf.st_ino)) {
+		close (fd);
 		return 0;
+	}
 
 	/* There's also no point reading zero byte files, since they
 	 * won't have any blocks (and we can't mmap zero bytes anyway).


### PR DESCRIPTION
Commit 61bd7e6 ("Use newly implemented set to replace NihHash") replaced a usage of NihHash with newly introduced hash set.
One of the hash set usage is keeping track of files already processed by the tracer. one check involves opening fd of a file, obtaining device id & inode through it for checking if it's already stored in the hash set. if it is, the file gets ignored.

While replacing the code that performs check mentioned above, it accidentally removed `close(fd)` call that would have properly closed the opened fd before moving onto the next file for processing.

Re-introduce `close(fd)` to appropriate location so that fd won't get leaked.